### PR TITLE
Update packages before install

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,6 +3,7 @@ set -x
 
 # Install necessary dependencies
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+sudo apt-get update
 sudo apt-get -y -qq install curl wget git vim apt-transport-https ca-certificates
 sudo add-apt-repository ppa:longsleep/golang-backports -y
 sudo apt -y -qq install golang-go


### PR DESCRIPTION
When I was try [the tutorial](https://learn.hashicorp.com/tutorials/terraform/packer), faced following error.

```
==> amazon-ebs: + sudo apt -y -qq install golang-go
==> amazon-ebs:
==> amazon-ebs: WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
==> amazon-ebs:
    amazon-ebs: The following additional packages will be installed:
    amazon-ebs:   binutils build-essential cpp cpp-5 dpkg-dev fakeroot g++ g++-5 gcc gcc-5
    amazon-ebs:   golang-1.6-go golang-1.6-race-detector-runtime golang-1.6-src
    amazon-ebs:   golang-race-detector-runtime golang-src libalgorithm-diff-perl
    amazon-ebs:   libalgorithm-diff-xs-perl libalgorithm-merge-perl libasan2 libatomic1
    amazon-ebs:   libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libdpkg-perl libfakeroot
    amazon-ebs:   libfile-fcntllock-perl libgcc-5-dev libgomp1 libisl15 libitm1 liblsan0
    amazon-ebs:   libmpc3 libmpx0 libquadmath0 libstdc++-5-dev libtsan0 libubsan0
    amazon-ebs:   linux-libc-dev make manpages-dev pkg-config
    amazon-ebs: Suggested packages:
    amazon-ebs:   binutils-doc cpp-doc gcc-5-locales debian-keyring g++-multilib
    amazon-ebs:   g++-5-multilib gcc-5-doc libstdc++6-5-dbg gcc-multilib autoconf automake
    amazon-ebs:   libtool flex bison gdb gcc-doc gcc-5-multilib libgcc1-dbg libgomp1-dbg
    amazon-ebs:   libitm1-dbg libatomic1-dbg libasan2-dbg liblsan0-dbg libtsan0-dbg
    amazon-ebs:   libubsan0-dbg libcilkrts5-dbg libmpx0-dbg libquadmath0-dbg bzr mercurial
    amazon-ebs:   subversion glibc-doc libstdc++-5-doc make-doc
    amazon-ebs: The following NEW packages will be installed:
    amazon-ebs:   binutils build-essential cpp cpp-5 dpkg-dev fakeroot g++ g++-5 gcc gcc-5
    amazon-ebs:   golang-1.6-go golang-1.6-race-detector-runtime golang-1.6-src golang-go
    amazon-ebs:   golang-race-detector-runtime golang-src libalgorithm-diff-perl
    amazon-ebs:   libalgorithm-diff-xs-perl libalgorithm-merge-perl libasan2 libatomic1
    amazon-ebs:   libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libdpkg-perl libfakeroot
    amazon-ebs:   libfile-fcntllock-perl libgcc-5-dev libgomp1 libisl15 libitm1 liblsan0
    amazon-ebs:   libmpc3 libmpx0 libquadmath0 libstdc++-5-dev libtsan0 libubsan0
    amazon-ebs:   linux-libc-dev make manpages-dev pkg-config
==> amazon-ebs: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.4.0-193.224_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
==> amazon-ebs:
    amazon-ebs: 0 upgraded, 43 newly installed, 0 to remove and 0 not upgraded.
    amazon-ebs: Need to get 65.9 MB of archives.
==> amazon-ebs: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
    amazon-ebs: After this operation, 342 MB of additional disk space will be used.
```

Then I was fix this.
