### PR TITLE
Update variables.tf

### DIFF
--- a/instances/variables.tf
+++ b/instances/variables.tf
@@ -12,7 +12,7 @@ variable "environment_tag" {
   default     = "Learn"
 }
 
-variable "region" {
+variable "aws_region" {
   description = "The region Terraform deploys your instance"
 }
 


### PR DESCRIPTION
1.  `main.tf` expects `region = var.aws_region`

2.  Corresponding guide also requires fix regarding creation of `terraform.tfvars`
https://learn.hashicorp.com/tutorials/terraform/cloud-init#add-the-cloud-init-script-to-the-terraform-configuration
```
aws_region = "us-east-1"
````