### PR TITLE
fixing a discrepancy with the *region* vs *aws_region* variable name

### DIFF
--- a/instances/main.tf
+++ b/instances/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 
 provider "aws" {
-  region = var.aws_region
+  region = var.region
 }
 
 data "aws_ami" "ubuntu" {


### PR DESCRIPTION
There was a discrepancy in the variable names, that was preventing the TF code to run.

This is basically the opposite of https://github.com/hashicorp/learn-terraform-provisioning/pull/8, and will not require a change to the https://learn.hashicorp.com/tutorials/terraform/cloud-init page.