### PR TITLE
Fixes #23 - replace vsphere plugin with amazon plugin

### DIFF
--- a/images/image.pkr.hcl
+++ b/images/image.pkr.hcl
@@ -4,8 +4,8 @@
 packer {
   required_plugins {
     vsphere = {
-      version = ">= 1.2.3"
-      source  = "github.com/hashicorp/vsphere"
+      version = "~> 1"
+      source  = "github.com/hashicorp/amazon"
     }
   }
 }


### PR DESCRIPTION
Fixes #23

Just a simple replace of the plugin from vsphere to amazon so that this repo matches with the tutorial at https://developer.hashicorp.com/terraform/tutorials/provision/packer 